### PR TITLE
Automate "Load more" clicking in XCancel thread scraper

### DIFF
--- a/xcancel_scrape_thread.js
+++ b/xcancel_scrape_thread.js
@@ -50,5 +50,11 @@ javascript:
     added++;
   }
   sessionStorage.setItem(KEY, JSON.stringify(stored));
-  alert('Added ' + added + ' tweets. Total: ' + stored.tweets.length + '. Click Load more then run again.');
+  var loadMore = document.querySelector('div.show-more a[href="?"]');
+  if (loadMore) {
+    console.log('Scraped ' + added + ' tweets (total: ' + stored.tweets.length + '). Clicking Load more...');
+    loadMore.click();
+  } else {
+    alert('Scraping complete! Total: ' + stored.tweets.length + ' tweets.\nNo more tweets to load — use the Render Scraped Thread bookmarklet to view and export.');
+  }
 })();

--- a/xcancel_scrape_thread_README.md
+++ b/xcancel_scrape_thread_README.md
@@ -25,10 +25,9 @@ Drag each generated link to your browser's bookmarks bar.
 
 1. Navigate to a thread page on xcancel.com (e.g., `https://xcancel.com/user/status/123456`).
 2. Click the **Scrape XCancel Thread** bookmarklet.
-3. An alert confirms how many tweets were added and the running total.
-4. If the thread has more replies, click **"Load more"** on the page to reveal the next batch.
-5. Click the bookmarklet again to scrape the newly visible tweets.
-6. Repeat steps 4-5 until all replies are captured.
+3. The bookmarklet scrapes all visible tweets, then automatically clicks the **"Load more"** link if one is present. The page will reload with new tweets.
+4. Click the bookmarklet again to scrape the newly loaded tweets and auto-load the next batch.
+5. Repeat until an alert tells you scraping is complete — this means there are no more tweets to load.
 
 The scraper is additive — each run appends only new (unseen) tweets to the collection, so you can safely run it multiple times on the same page without duplicates.
 


### PR DESCRIPTION
## Summary
Enhanced the XCancel thread scraper bookmarklet to automatically click the "Load more" link when available, eliminating the need for manual intervention between scraping runs.

## Key Changes
- **Automated pagination**: The scraper now automatically detects and clicks the "Load more" link after each scrape, allowing continuous data collection without manual page interaction
- **Improved user feedback**: Replaced the alert prompt with console logging during scraping, and only shows an alert when scraping is truly complete (no more tweets to load)
- **Updated documentation**: Simplified the usage instructions to reflect the new automatic workflow, reducing the number of manual steps from 6 to 5

## Implementation Details
- Added DOM query to find the "Load more" link (`div.show-more a[href="?"]`)
- Conditional logic: if the link exists, it's automatically clicked; if not, a completion alert is shown
- Console logging provides real-time feedback on scraping progress without interrupting the workflow
- The automatic clicking enables a more seamless scraping experience, especially for threads with many replies

https://claude.ai/code/session_018KW3unDcNUY62fgHPQkeCE