### PR TITLE
Add markdown_renderer bookmarklet

### DIFF
--- a/markdown_renderer.js
+++ b/markdown_renderer.js
@@ -1,0 +1,56 @@
+javascript:
+/* @title: Render Markdown */
+/* @description: Renders raw markdown (markdown content-type, single PRE body, or plain body text) as styled HTML with a light/dark theme toggle */
+(function() {
+    /* Detect markdown source on the current page */
+    let src = '';
+    const pre = document.body && document.body.firstElementChild;
+    if (document.contentType && /markdown/i.test(document.contentType)) {
+        src = document.body.innerText;
+    } else if (document.body.children.length === 1 && pre && pre.tagName === 'PRE') {
+        src = pre.innerText;
+    } else {
+        src = document.body.innerText;
+    }
+
+    /* Apply (and persist) light/dark theme; update toggle label */
+    function applyTheme(t) {
+        document.documentElement.setAttribute('data-md-theme', t);
+        try { localStorage.setItem('mdBookmarkletTheme', t); } catch (e) {}
+        const btn = document.getElementById('md-theme-toggle');
+        if (btn) btn.textContent = t === 'dark' ? '\u2600\ufe0f Light' : '\uD83C\uDF19 Dark';
+    }
+
+    /* Render markdown into the page */
+    function render(md) {
+        const html = window.marked.parse(md);
+        document.body.innerHTML = '<button id="md-theme-toggle" type="button"></button><div id="md-rendered">' + html + '</div>';
+
+        const s = document.createElement('style');
+        s.textContent = 'html{color-scheme:light}html[data-md-theme="dark"]{color-scheme:dark}html,body{margin:0}html[data-md-theme="light"],html[data-md-theme="light"] body{background:#fff!important;color:#24292e!important}html[data-md-theme="dark"],html[data-md-theme="dark"] body{background:#0d1117!important;color:#c9d1d9!important}#md-theme-toggle{position:fixed;top:12px;right:16px;z-index:9999;border:1px solid #d0d7de;background:#f6f8fa;color:#24292e;padding:6px 12px;border-radius:6px;font:13px -apple-system,Segoe UI,sans-serif;cursor:pointer;box-shadow:0 1px 2px rgba(0,0,0,.1)}#md-theme-toggle:hover{background:#eaeef2}html[data-md-theme="dark"] #md-theme-toggle{background:#21262d;color:#c9d1d9;border-color:#30363d}html[data-md-theme="dark"] #md-theme-toggle:hover{background:#30363d}#md-rendered{max-width:880px;margin:24px auto;padding:0 24px;font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;line-height:1.6}#md-rendered h1,#md-rendered h2{padding-bottom:.3em;border-bottom:1px solid}html[data-md-theme="light"] #md-rendered h1,html[data-md-theme="light"] #md-rendered h2{border-color:#eaecef}html[data-md-theme="dark"] #md-rendered h1,html[data-md-theme="dark"] #md-rendered h2{border-color:#30363d}#md-rendered a{color:#0366d6}html[data-md-theme="dark"] #md-rendered a{color:#58a6ff}#md-rendered code{padding:2px 6px;border-radius:4px;font-family:ui-monospace,Consolas,monospace}#md-rendered pre{padding:12px;border-radius:6px;overflow:auto}html[data-md-theme="light"] #md-rendered code,html[data-md-theme="light"] #md-rendered pre{background:#f6f8fa}html[data-md-theme="dark"] #md-rendered code,html[data-md-theme="dark"] #md-rendered pre{background:#161b22}#md-rendered pre code{background:transparent!important;padding:0}#md-rendered table{border-collapse:collapse}#md-rendered th,#md-rendered td{border:1px solid;padding:6px 12px}html[data-md-theme="light"] #md-rendered th,html[data-md-theme="light"] #md-rendered td{border-color:#dfe2e5}html[data-md-theme="dark"] #md-rendered th,html[data-md-theme="dark"] #md-rendered td{border-color:#30363d}#md-rendered blockquote{border-left:4px solid;padding:0 1em;margin:0}html[data-md-theme="light"] #md-rendered blockquote{border-color:#dfe2e5;color:#6a737d}html[data-md-theme="dark"] #md-rendered blockquote{border-color:#30363d;color:#8b949e}#md-rendered hr{border:0;border-top:1px solid}html[data-md-theme="light"] #md-rendered hr{border-color:#eaecef}html[data-md-theme="dark"] #md-rendered hr{border-color:#30363d}';
+        document.head.appendChild(s);
+
+        let saved;
+        try { saved = localStorage.getItem('mdBookmarkletTheme'); } catch (e) {}
+        const initial = saved || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        applyTheme(initial);
+
+        document.getElementById('md-theme-toggle').addEventListener('click', function() {
+            applyTheme(document.documentElement.getAttribute('data-md-theme') === 'dark' ? 'light' : 'dark');
+        });
+
+        /* Use first H1 as document title if present */
+        const m = md.match(/^#\s+(.+)/m);
+        if (m) document.title = m[1];
+    }
+
+    /* Load marked.js if not already present, then render */
+    if (window.marked) {
+        render(src);
+    } else {
+        const sc = document.createElement('script');
+        sc.src = 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+        sc.onload = function() { render(src); };
+        document.head.appendChild(sc);
+    }
+})();

--- a/markdown_renderer_README.md
+++ b/markdown_renderer_README.md
@@ -1,0 +1,71 @@
+# Markdown Renderer
+
+Renders raw markdown on the current page as styled HTML, with a persistent light/dark theme toggle. Useful for `.md` files served as plain text by GitHub raw, S3, Pages, gists, or anything that serves the source instead of rendering it.
+
+## Purpose
+
+Click on a raw markdown URL (e.g. `raw.githubusercontent.com/.../README.md`, an S3 bucket, a local file, an internal docs server) and the browser shows you the source. This bookmarklet replaces that view with a GitHub-style rendered version, in place. No new tab, no copy-paste, no detour through a dedicated viewer.
+
+Common use cases:
+- Reading raw GitHub markdown without going back to the rendered repo view
+- Skimming markdown attachments served as `text/plain`
+- Reviewing local `.md` files opened in the browser
+- Reading markdown from internal tools that don't render it
+
+## Features
+
+- **Smart source detection**: Picks the markdown body whether the page is served as `text/markdown`, as a single `<pre>` block (the typical raw view), or as plain body text.
+- **GitHub-style rendering**: Headings, code blocks, tables, blockquotes, and links styled to match GitHub's light and dark themes.
+- **Light/dark toggle**: Fixed button in the top-right; choice is persisted in `localStorage` (`mdBookmarkletTheme`) across pages and sessions.
+- **System-default first run**: On first use, picks light or dark based on `prefers-color-scheme`.
+- **Title from H1**: Sets the document title to the first `# H1` in the source, so the browser tab reflects what you're reading.
+- **Idempotent loader**: Reuses `window.marked` if it's already on the page; otherwise loads `marked.min.js` from jsdelivr on demand.
+
+## Installation
+
+1.  **Easy Mode**:
+    *   Go to the [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html?bookmarklet=markdown_renderer.js)
+    *   Drag the generated link to your bookmarks bar.
+2.  **Hard Mode**:
+    *   Copy the entire JavaScript code from the [markdown_renderer.js file](https://github.com/oaustegard/bookmarklets/blob/main/markdown_renderer.js).
+    *   Go to the generic [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html).
+    *   Paste the code into the installer.
+    *   Name the bookmarklet (e.g., "Render Markdown").
+    *   Drag the generated link to your bookmarks bar.
+
+## Usage
+
+1.  Navigate to any page whose body is markdown source — for example a `raw.githubusercontent.com` URL, an S3-hosted `.md` file, or a local `file:///.../README.md`.
+2.  Click the "Render Markdown" bookmarklet.
+3.  The page is replaced in place with rendered HTML. Use the button in the top-right to toggle light/dark.
+
+## How It Works
+
+1.  **Source detection**: Picks `src` from the first matching rule:
+    *   `document.contentType` matches `/markdown/i` → use `document.body.innerText`.
+    *   Body has a single child that is a `<pre>` element (the typical raw-text view) → use `pre.innerText`.
+    *   Otherwise → fall back to `document.body.innerText`.
+2.  **Loader**: If `window.marked` is already defined, render immediately. Otherwise inject `<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js">` and render in its `onload`.
+3.  **Render**: Calls `marked.parse(src)`, replaces `document.body` with a fixed-position theme toggle button plus a `#md-rendered` container holding the parsed HTML.
+4.  **Styling**: Injects a single `<style>` element scoped via the `data-md-theme` attribute on `<html>`. Both light and dark variants are defined; the active one is selected by attribute value.
+5.  **Theme**: Reads saved theme from `localStorage` under `mdBookmarkletTheme`; falls back to `matchMedia('(prefers-color-scheme: dark)')`. The toggle button flips the attribute and re-saves.
+6.  **Title**: Matches `/^#\s+(.+)/m` against the source; if found, sets `document.title` to the first H1 text.
+
+## Notes & Caveats
+
+- The script replaces `document.body.innerHTML`, so any original page state (form input, scroll-restored elements) is discarded once the bookmarklet runs.
+- Reading from `localStorage` is wrapped in `try/catch`; the bookmarklet still works on origins that block storage, you just lose persistence of the theme choice.
+- Loading `marked.min.js` from jsdelivr requires the page's CSP to allow `script-src cdn.jsdelivr.net`. Strict-CSP pages will block it; in that case, save the page as `.md` locally and run the bookmarklet there.
+- No syntax highlighting — code blocks are rendered as plain `<pre><code>`. Add a highlighter (e.g. `highlight.js`) to the loader if you need it.
+
+## Source Code
+
+The full source code is available on [GitHub](https://github.com/oaustegard/bookmarklets/blob/main/markdown_renderer.js).
+
+## License
+
+MIT License - See [LICENSE](https://github.com/oaustegard/bookmarklets/blob/main/LICENSE)
+
+## Author
+
+Created by [Oskar Austegard](https://austegard.com)


### PR DESCRIPTION
Renders raw markdown on the current page as styled HTML with a persistent light/dark theme toggle. Useful when the browser shows you `.md` source instead of rendering it (raw GitHub URLs, S3-hosted docs, local files, etc.).

**Source detection** picks the body whether the page is served as `text/markdown`, as a single `<pre>` block (typical raw view), or as plain body text.

**Behavior:**
- Replaces `document.body` in place with a GitHub-styled rendering and a fixed top-right theme toggle
- Theme persists in `localStorage` (`mdBookmarkletTheme`); first run honors `prefers-color-scheme`
- Sets `document.title` from the first `# H1`
- Loads `marked.min.js` from jsdelivr only if `window.marked` isn't already present

**Files:**
- `markdown_renderer.js` — IIFE with `@title`/`@description` metadata, expanded from the original minified form per AGENTS.md conventions
- `markdown_renderer_README.md` — follows the standard repo README template

No `@domains` set — works on any page that contains markdown.

*Filed by Muninn*
