### PR TITLE
Update sharepoint_file_path: structural detection, no domain allowlist

### DIFF
--- a/sharepoint_file_path.js
+++ b/sharepoint_file_path.js
@@ -1,13 +1,7 @@
 javascript:(function() {
 /* @title: Get SharePoint File Path */
 /* @description: Generates a Windows Explorer-compatible file path for SharePoint document libraries */
-    /* Verify we're on a SharePoint site */
-    if (typeof SP === 'undefined' || typeof SP.Site === 'undefined') {
-        alert('This doesn\'t appear to be a SharePoint site.');
-        return;
-    }
-
-    /* Validate domain -- change as needed*/
+    /* Validate domain -- change as needed */
     function isValidDomain(server) {
         return (
             server.endsWith('.ACME.com') ||
@@ -36,7 +30,7 @@ javascript:(function() {
         }
 
         /* Remove query parameters and specific SharePoint paths */
-        path = path.split('?')[0].replace(/\/Forms\/AllItems\.aspx$/, '').replace(/\/SitePages\/.*$/, '/SitePages');
+        path = path.split('?')[0].replace(/\/Forms\/[^\/]+\.aspx$/, '').replace(/\/SitePages\/.*$/, '/SitePages');
 
         return { server: server, path: path };
     }

--- a/sharepoint_file_path.js
+++ b/sharepoint_file_path.js
@@ -1,13 +1,10 @@
 javascript:(function() {
 /* @title: Get SharePoint File Path */
 /* @description: Generates a Windows Explorer-compatible file path for SharePoint document libraries */
-    /* Validate domain -- change as needed */
-    function isValidDomain(server) {
-        return (
-            server.endsWith('.ACME.com') ||
-            server.endsWith('.AC-ME.com') ||
-            !server.includes('.')
-        );
+    /* Detect SharePoint document libraries, list views, and site pages by URL structure.
+       Works on any host -- no domain allowlist needed. */
+    function looksLikeSharePoint(url) {
+        return /(?:_layouts\/|[?&]RootFolder=|\/Forms\/[^\/]+\.aspx|\/SitePages(?:\/|$))/i.test(url);
     }
 
     /* Extract the server name and path from the current URL */
@@ -17,8 +14,8 @@ javascript:(function() {
         var server = match[1];
         var path = match[2];
 
-        if (!isValidDomain(server)) {
-            alert('This doesn\'t appear to be a valid local SharePoint site.');
+        if (!looksLikeSharePoint(url)) {
+            alert('This doesn\'t look like a SharePoint document library, list, or site page.');
             return null;
         }
 

--- a/sharepoint_file_path_README.md
+++ b/sharepoint_file_path_README.md
@@ -8,10 +8,10 @@ This bookmarklet helps users who need to access SharePoint files or folders dire
 
 ## Features
 
--   **SharePoint Specific**: Checks for the presence of SharePoint's `SP` JavaScript object.
--   **Domain Validation**: Includes a function `isValidDomain` to check if the SharePoint server matches a list of predefined "local" domains (e.g., `.ACME.com`). This needs customization for other organizations.
+-   **Domain Validation**: Includes a function `isValidDomain` to check if the SharePoint server matches a list of predefined "local" domains (e.g., `.ACME.com`). **This needs customization for your organization.**
 -   **URL Parsing**: Handles different SharePoint URL formats, including those with `_layouts/15/start.aspx#/` or `RootFolder=`.
 -   **Path Transformation**: Converts the web path to a `file://` path using `DavWWWRoot`.
+-   **Form-Page Stripping**: Removes any trailing `/Forms/<page>.aspx` (e.g. `AllItems.aspx`, `DispForm.aspx`) and collapses `/SitePages/...` to `/SitePages`.
 -   **Dialog Display**: Shows the generated path in a temporary dialog box at the bottom-right of the page.
 -   **Clipboard Integration**: Automatically copies the generated path to the clipboard.
 -   **Auto-Close Dialog**: The dialog closes automatically after 10 seconds or when a "Close" button is clicked.
@@ -23,7 +23,7 @@ This bookmarklet helps users who need to access SharePoint files or folders dire
     *   Drag the generated link to your bookmarks bar.
 2.  **Hard Mode**:
     *   Copy the entire JavaScript code from the [sharepoint_file_path.js file](https://github.com/oaustegard/bookmarklets/blob/main/sharepoint_file_path.js).
-    *   **Important**: You may need to customize the `isValidDomain` function within the code to match your organization's SharePoint domains.
+    *   **Important**: You must customize the `isValidDomain` function within the code to match your organization's SharePoint domains (the published version uses `.ACME.com` / `.AC-ME.com` placeholders).
     *   Go to the generic [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html).
     *   Paste the modified code into the installer.
     *   Name the bookmarklet (e.g., "SP to File Path").
@@ -33,42 +33,35 @@ This bookmarklet helps users who need to access SharePoint files or folders dire
 
 1.  Navigate to a document library, folder, or file within your organization's SharePoint site.
 2.  Click the "SP to File Path" bookmarklet.
-3.  If the page is recognized as a valid SharePoint site and domain:
+3.  If the page is on a valid (configured) domain:
     *   A small dialog will appear in the bottom-right corner displaying the generated Windows Explorer path.
     *   This path will also be copied to your clipboard.
-4.  You can then try pasting this path into the Windows File Explorer address bar.
+4.  Paste this path into the Windows File Explorer address bar.
 5.  The dialog will close on its own after 10 seconds or if you click its "Close" button.
-6.  Alerts will appear if it's not a SharePoint site, not a valid local domain, or if path extraction fails.
+6.  An alert appears if the current domain is not in the configured list, or if path extraction fails.
 
 ## How It Works
 
-1.  **SharePoint Check**: Verifies `typeof SP !== 'undefined' && typeof SP.Site !== 'undefined'`.
-2.  **`isValidDomain(server)` Function**:
-    *   Checks if the server name ends with predefined domain suffixes (e.g., `.ACME.com`, `.AC-ME.com`) or has no dots (implying a local server name). **This function needs to be customized for your specific SharePoint environment.**
-3.  **`extractPathInfo(url)` Function**:
-    *   Parses `window.location.href` to get the server and path.
+1.  **`isValidDomain(server)`**: Checks if the server name ends with predefined domain suffixes (e.g., `.ACME.com`, `.AC-ME.com`) or has no dots (implying a local server name). **Customize this for your specific SharePoint environment.**
+2.  **`extractPathInfo(url)`**:
+    *   Parses `window.location.href` into server and path.
     *   Calls `isValidDomain`. If invalid, alerts and returns `null`.
     *   Handles different SharePoint URL structures:
-        *   If URL contains `_layouts/15/start.aspx#/`, it takes the part after the `#`.
-        *   If URL contains `RootFolder=`, it decodes and takes the value of `RootFolder`.
-    *   Cleans the path by removing query parameters and common endings like `/Forms/AllItems.aspx` or `/SitePages/...` (replacing the latter with just `/SitePages`).
-4.  **`createExplorerPath(pathInfo)` Function**:
-    *   Prepends `file://` to the server name and inserts `/DavWWWRoot` before the path: `file://{server}/DavWWWRoot{path}`.
-5.  **`copyToClipboard(text)` Function**: Standard textarea-based clipboard copying.
-6.  **`showAndCopyPath(path)` Function**:
-    *   Creates a styled `div` for the dialog.
-    *   Sets its `innerHTML` with the path and a close button.
-    *   Appends dialog to `document.body`.
-    *   Calls `copyToClipboard`.
-    *   Sets up the close button's `onclick` and a `setTimeout` to remove the dialog.
-7.  **Main Execution**: Calls `extractPathInfo`, then `createExplorerPath`, then `showAndCopyPath`.
+        *   If the URL contains `_layouts/15/start.aspx#/`, it takes the part after the `#`.
+        *   If the URL contains `RootFolder=`, it decodes and takes the value of `RootFolder`.
+    *   Cleans the path by removing query parameters and trailing `/Forms/<page>.aspx`, and collapsing `/SitePages/...` to `/SitePages`.
+3.  **`createExplorerPath(pathInfo)`**: Builds `file://{server}/DavWWWRoot{path}`.
+4.  **`copyToClipboard(text)`**: Textarea-based clipboard copy via `execCommand('copy')`.
+5.  **`showAndCopyPath(path)`**: Creates a styled dialog with the path and a close button, copies the path, and auto-removes the dialog after 10 seconds.
+6.  **Main Execution**: `extractPathInfo` → `createExplorerPath` → `showAndCopyPath`.
 
 ## Technical Notes
 
--   The reliability of `DavWWWRoot` paths depends on the client machine having the WebClient service running and proper authentication/network access to the SharePoint server.
--   The `isValidDomain` function is crucial and **must be configured** by the user for their specific SharePoint environment for the bookmarklet to work as intended.
+-   The reliability of `DavWWWRoot` paths depends on the client machine running the WebClient service with proper authentication and network access to the SharePoint server.
+-   The `isValidDomain` function is the only piece that **must** be configured for your environment.
 -   The URL parsing logic is heuristic and might not cover all SharePoint URL variations or custom setups.
+-   Unlike an earlier variant, this version does not gate on the legacy `SP` JavaScript global, so it also runs on pages where that object is not present.
 
 ## Source Code
 
-The full source code is available on [GitHub](https://github.com/oaustegard/bookmarklets/blob/main/sharepoint_file_path.js). Remember to check and customize `isValidDomain` if needed.
+The full source code is available on [GitHub](https://github.com/oaustegard/bookmarklets/blob/main/sharepoint_file_path.js). Remember to set `isValidDomain` to your own domains.

--- a/sharepoint_file_path_README.md
+++ b/sharepoint_file_path_README.md
@@ -1,6 +1,6 @@
 # SharePoint URL to Windows Explorer Path Converter
 
-Converts the current SharePoint document library or list URL into an equivalent Windows Explorer file path and copies it to the clipboard.
+Converts the current SharePoint document library, list, or site-page URL into an equivalent Windows Explorer file path and copies it to the clipboard.
 
 ## Purpose
 
@@ -8,10 +8,10 @@ This bookmarklet helps users who need to access SharePoint files or folders dire
 
 ## Features
 
--   **Domain Validation**: Includes a function `isValidDomain` to check if the SharePoint server matches a list of predefined "local" domains (e.g., `.ACME.com`). **This needs customization for your organization.**
+-   **Structural SharePoint Detection**: Identifies SharePoint pages by URL structure (`_layouts/`, `RootFolder=`, `/Forms/<page>.aspx`, `/SitePages`) rather than a domain allowlist — so it works on any host with no per-organization configuration.
 -   **URL Parsing**: Handles different SharePoint URL formats, including those with `_layouts/15/start.aspx#/` or `RootFolder=`.
 -   **Path Transformation**: Converts the web path to a `file://` path using `DavWWWRoot`.
--   **Form-Page Stripping**: Removes any trailing `/Forms/<page>.aspx` (e.g. `AllItems.aspx`, `DispForm.aspx`) and collapses `/SitePages/...` to `/SitePages`.
+-   **Form-Page Stripping**: Removes any trailing `/Forms/<page>.aspx` (e.g. `AllItems.aspx`, `ByAuthor.aspx`, `DispForm.aspx`) and collapses `/SitePages/...` to `/SitePages`.
 -   **Dialog Display**: Shows the generated path in a temporary dialog box at the bottom-right of the page.
 -   **Clipboard Integration**: Automatically copies the generated path to the clipboard.
 -   **Auto-Close Dialog**: The dialog closes automatically after 10 seconds or when a "Close" button is clicked.
@@ -23,29 +23,28 @@ This bookmarklet helps users who need to access SharePoint files or folders dire
     *   Drag the generated link to your bookmarks bar.
 2.  **Hard Mode**:
     *   Copy the entire JavaScript code from the [sharepoint_file_path.js file](https://github.com/oaustegard/bookmarklets/blob/main/sharepoint_file_path.js).
-    *   **Important**: You must customize the `isValidDomain` function within the code to match your organization's SharePoint domains (the published version uses `.ACME.com` / `.AC-ME.com` placeholders).
     *   Go to the generic [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html).
-    *   Paste the modified code into the installer.
+    *   Paste the code into the installer.
     *   Name the bookmarklet (e.g., "SP to File Path").
     *   Drag the generated link to your bookmarks bar.
 
 ## Usage
 
-1.  Navigate to a document library, folder, or file within your organization's SharePoint site.
+1.  Navigate to a document library, folder, list view, or site page within a SharePoint site.
 2.  Click the "SP to File Path" bookmarklet.
-3.  If the page is on a valid (configured) domain:
+3.  If the page is recognized as SharePoint:
     *   A small dialog will appear in the bottom-right corner displaying the generated Windows Explorer path.
     *   This path will also be copied to your clipboard.
 4.  Paste this path into the Windows File Explorer address bar.
 5.  The dialog will close on its own after 10 seconds or if you click its "Close" button.
-6.  An alert appears if the current domain is not in the configured list, or if path extraction fails.
+6.  An alert appears if the page doesn't look like a SharePoint library/list/site page, or if path extraction fails.
 
 ## How It Works
 
-1.  **`isValidDomain(server)`**: Checks if the server name ends with predefined domain suffixes (e.g., `.ACME.com`, `.AC-ME.com`) or has no dots (implying a local server name). **Customize this for your specific SharePoint environment.**
+1.  **`looksLikeSharePoint(url)`**: Tests the current URL for SharePoint structural markers — `_layouts/`, a `RootFolder=` query parameter, a `/Forms/<page>.aspx` view, or `/SitePages`. No host or domain is hard-coded.
 2.  **`extractPathInfo(url)`**:
     *   Parses `window.location.href` into server and path.
-    *   Calls `isValidDomain`. If invalid, alerts and returns `null`.
+    *   Calls `looksLikeSharePoint`. If it doesn't match, alerts and returns `null`.
     *   Handles different SharePoint URL structures:
         *   If the URL contains `_layouts/15/start.aspx#/`, it takes the part after the `#`.
         *   If the URL contains `RootFolder=`, it decodes and takes the value of `RootFolder`.
@@ -58,10 +57,9 @@ This bookmarklet helps users who need to access SharePoint files or folders dire
 ## Technical Notes
 
 -   The reliability of `DavWWWRoot` paths depends on the client machine running the WebClient service with proper authentication and network access to the SharePoint server.
--   The `isValidDomain` function is the only piece that **must** be configured for your environment.
+-   Detection is structural, so the bookmarklet works across organizations without editing the code.
 -   The URL parsing logic is heuristic and might not cover all SharePoint URL variations or custom setups.
--   Unlike an earlier variant, this version does not gate on the legacy `SP` JavaScript global, so it also runs on pages where that object is not present.
 
 ## Source Code
 
-The full source code is available on [GitHub](https://github.com/oaustegard/bookmarklets/blob/main/sharepoint_file_path.js). Remember to set `isValidDomain` to your own domains.
+The full source code is available on [GitHub](https://github.com/oaustegard/bookmarklets/blob/main/sharepoint_file_path.js).


### PR DESCRIPTION
Updates the existing `sharepoint_file_path` bookmarklet so it works on any SharePoint host, with no per-organization configuration.

**Changes vs prior committed version:**
- Removes the corporate domain allowlist (`isValidDomain`) entirely — it rejected valid SharePoint URLs on other hosts.
- Adds `looksLikeSharePoint(url)`: detects SharePoint by URL structure — `_layouts/`, a `RootFolder=` query param, a `/Forms/<page>.aspx` view, or `/SitePages`.
- Removes the legacy `if (typeof SP === 'undefined' ...)` gate (ran only on classic pages).
- Broadens the trailing-form strip from `/Forms/AllItems.aspx` to any `/Forms/<page>.aspx` (e.g. `ByAuthor.aspx`, `DispForm.aspx`).
- Keeps the `@title` / `@description` headers used by the installer and the auto-README workflow.

Verified the matcher fires on library views, list views, `_layouts/start.aspx`, `RootFolder=` links, and `/SitePages`, and does not fire on non-SharePoint URLs (google/wikipedia/github).

README updated to match.

Note: `auto_readme.yml` regenerates the README via GitHub Models when the `.js` lands on `main`; the README here is the review-time version.

*Filed by Muninn*