### PR TITLE
Update BSky Translator: thread posts, visibility filter, README

### DIFF
--- a/CONTENT_SUMMARY.md
+++ b/CONTENT_SUMMARY.md
@@ -64,6 +64,13 @@ Below is a list of available bookmarklets, their purpose, and links to their res
 
 ---
 
+### BSky Translator
+- **Purpose**: Toggles inline English translations beneath non-English posts in a BlueSky feed or thread, translating new posts automatically as you scroll.
+- **Source**: [`bsky_translator.js`](https://github.com/oaustegard/bookmarklets/blob/main/bsky_translator.js)
+- **Details**: [`bsky_translator_README.md`](https://github.com/oaustegard/bookmarklets/blob/main/bsky_translator_README.md)
+
+---
+
 ### BlueSky User Lists Viewer
 - **Purpose**: Provides a modal overlay to display all public lists created by a BlueSky user when viewing their profile page.
 - **Source**: [`bsky_user_lists.js`](https://github.com/oaustegard/bookmarklets/blob/main/bsky_user_lists.js)

--- a/bsky_translator.js
+++ b/bsky_translator.js
@@ -3,116 +3,134 @@ javascript:
 /* @description: Translates non-english posts on a bsky feed */
 /* @domains: bsky.app */
 (function() {
-  var W = window;
+  var W = window,
+    C = document;
+  /* Second click of the bookmarklet tears everything down */
   if (W.__bskyTr) {
     W.__bskyTr.stop();
     return
   }
-  var T = 'en',
-    S = '[data-testid="postText"]',
-    C = new Map,
-    Q = [],
+  var TL = 'en',
+    /* Feed posts expose data-testid="postText"; thread detail posts don't, so
+       match the wrapped text inside a postThreadItem-by-* container too */
+    SEL = '[data-testid="postText"],[data-testid^="postThreadItem-by-"] [data-word-wrap]',
+    cache = new Map,
+    queue = [],
     busy = 0,
-    on = 1,
-    tm, D = document,
-    b = D.createElement('div');
-  b.style.cssText = 'position:fixed;z-index:99999;bottom:12px;right:12px;background:%230a7aff;color:%23fff;font:12px sans-serif;padding:6px 10px;border-radius:14px;cursor:pointer';
-  b.textContent = 'EN translate: ON (click to stop)';
-  b.onclick = function() {
+    live = 1,
+    timer,
+    badge = C.createElement('div');
+  badge.style.cssText = 'position:fixed;z-index:99999;bottom:12px;right:12px;background:%230a7aff;color:%23fff;font:12px sans-serif;padding:6px 10px;border-radius:14px;cursor:pointer';
+  badge.textContent = 'EN translate: ON (click to stop)';
+  badge.onclick = function() {
     W.__bskyTr.stop()
   };
-  D.body.appendChild(b);
-  var api = function(t) {
-    return fetch('https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=' + T + '&dt=t&q=' + encodeURIComponent(t)).then(function(r) {
-      return r.json()
-    }).then(function(j) {
-      return {
-        text: j[0].map(function(s) {
-          return s[0]
-        }).join(''),
-        src: j[2]
-      }
-    })
-  };
-  var clr = function(e) {
-    var n = e.nextElementSibling;
-    if (n && n.dataset.bskyTr) n.remove()
-  };
-  var put = function(e, r) {
-    clr(e);
-    if (r.skip) return;
-    var d = D.createElement('div');
-    d.dataset.bskyTr = 1;
-    d.style.cssText = 'margin-top:6px;padding:6px 8px;border-left:3px solid %230a7aff;background:rgba(10,122,255,.08);font-size:.95em;white-space:pre-wrap';
-    d.textContent = '[' + r.src + '>' + T + '] ' + r.text;
-    e.insertAdjacentElement('afterend', d)
-  };
-  var pump = async function() {
-    if (busy) return;
-    busy = 1;
-    while (Q.length && on) {
-      var i = Q.shift(),
-        e = i.el,
-        t = i.text;
-      if (!e.isConnected || e.dataset.trKey !== t) continue;
-      var r = C.get(t);
-      if (!r) {
-        try {
-          var o = await api(t);
-          r = (o.src === T || !o.text.trim() || o.text.trim() === t) ? {
-            skip: 1
-          } : o;
-          C.set(t, r)
-        } catch (x) {
-          continue
+  C.body.appendChild(badge);
+
+  /* Skip nodes that are in the DOM but not rendered (virtualized list slots) */
+  var vis = function(e) {
+      return !!(e.offsetParent || e.getClientRects().length)
+    },
+    tr = function(t) {
+      return fetch('https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=' + TL + '&dt=t&q=' + encodeURIComponent(t)).then(function(r) {
+        return r.json()
+      }).then(function(j) {
+        return {
+          text: j[0].map(function(x) {
+            return x[0]
+          }).join(''),
+          src: j[2]
         }
-        await new Promise(function(f) {
-          setTimeout(f, 200)
-        })
-      }
-      if (e.dataset.trKey === t) put(e, r)
-    }
-    busy = 0
-  };
-  var scan = function() {
-    D.querySelectorAll(S).forEach(function(e) {
-      var t = e.innerText.trim();
-      if (!t || e.dataset.trKey === t) return;
-      e.dataset.trKey = t;
-      clr(e);
-      var h = C.get(t);
-      h ? put(e, h) : Q.push({
-        el: e,
-        text: t
       })
-    });
-    pump()
-  };
-  var go = function() {
-    clearTimeout(tm);
-    tm = setTimeout(scan, 200)
-  };
-  var mo = new MutationObserver(go);
-  mo.observe(D.body, {
+    },
+    clr = function(e) {
+      var n = e.nextElementSibling;
+      n && n.dataset.bskyTr && n.remove()
+    },
+    show = function(e, r) {
+      if (clr(e), !r.skip) {
+        var d = C.createElement('div');
+        d.dataset.bskyTr = 1;
+        d.style.cssText = 'margin-top:6px;padding:6px 8px;border-left:3px solid %230a7aff;background:rgba(10,122,255,.08);font-size:.95em;white-space:pre-wrap';
+        d.textContent = '[' + r.src + '\u2192' + TL + '] ' + r.text;
+        e.insertAdjacentElement('afterend', d)
+      }
+    },
+    scan = function() {
+      C.querySelectorAll(SEL).forEach(function(e) {
+        if (vis(e)) {
+          var t = e.innerText.trim();
+          /* trKey doubles as "already handled" marker and staleness check */
+          if (t && e.dataset.trKey !== t) {
+            e.dataset.trKey = t;
+            clr(e);
+            var c = cache.get(t);
+            c ? show(e, c) : queue.push({
+              el: e,
+              text: t
+            })
+          }
+        }
+      });
+      /* Single drainer: serializes the queue so we never burst the endpoint */
+      (async function() {
+        if (!busy) {
+          for (busy = 1; queue.length && live;) {
+            var j = queue.shift(),
+              e = j.el,
+              t = j.text;
+            if (e.isConnected && e.dataset.trKey === t) {
+              var c = cache.get(t);
+              if (!c) {
+                try {
+                  var r = await tr(t);
+                  /* Cache the negative result too, so already-English text is
+                     never re-fetched on the next scan */
+                  c = r.src !== TL && r.text.trim() && r.text.trim() !== t ? r : {
+                    skip: 1
+                  };
+                  cache.set(t, c)
+                } catch (x) {
+                  continue
+                }
+                await new Promise(function(f) {
+                  setTimeout(f, 200)
+                })
+              }
+              /* Node may have been recycled while awaiting */
+              e.dataset.trKey === t && show(e, c)
+            }
+          }
+          busy = 0
+        }
+      })()
+    },
+    kick = function() {
+      clearTimeout(timer);
+      timer = setTimeout(scan, 250)
+    },
+    mo = new MutationObserver(kick);
+  mo.observe(C.body, {
     childList: 1,
     subtree: 1,
     characterData: 1
   });
-  addEventListener('scroll', go, 1);
+  addEventListener('scroll', kick, 1);
   scan();
+
   W.__bskyTr = {
     stop: function() {
-      on = 0;
+      live = 0;
       mo.disconnect();
-      removeEventListener('scroll', go, 1);
-      b.remove();
-      D.querySelectorAll('[data-bsky-tr]').forEach(function(n) {
-        n.remove()
+      removeEventListener('scroll', kick, 1);
+      badge.remove();
+      C.querySelectorAll('[data-bsky-tr]').forEach(function(e) {
+        e.remove()
       });
-      D.querySelectorAll(S).forEach(function(e) {
+      C.querySelectorAll(SEL).forEach(function(e) {
         delete e.dataset.trKey
       });
       delete W.__bskyTr
     }
   }
-})()
+})();

--- a/bsky_translator_README.md
+++ b/bsky_translator_README.md
@@ -1,0 +1,91 @@
+# BSky Translator Bookmarklet
+
+This bookmarklet translates non-English posts inline as you scroll a Bluesky feed or thread, appending an English rendering directly beneath each foreign-language post without leaving the page.
+
+## Purpose
+
+Bluesky has no built-in translation. Following accounts that post in Japanese, Portuguese, German, or anything else means either skipping their posts or copy-pasting them into a translation site one at a time. This bookmarklet turns translation into a toggle: click it once and every non-English post in view sprouts an English version underneath, including posts that load later as you scroll.
+
+## Features
+
+- **Inline translations** — an accent-bordered block appended after each post, tagged with the detected source language (e.g. `[ja→en] ...`)
+- **Feeds and threads** — matches feed posts *and* posts on the thread detail page, where Bluesky uses a different DOM structure
+- **Auto-translates on scroll** — a `MutationObserver` plus scroll listener picks up posts as Bluesky's virtualized list renders them
+- **Skips English** — posts already detected as English get no translation block
+- **Caches by post text** — repeated text (reposts, quote chains, re-rendered nodes) is translated once, not once per appearance
+- **Serialized requests** — a single queue drainer with a 200 ms gap between calls, so a fast scroll doesn't burst the endpoint
+- **Click-to-stop badge** — a floating badge in the bottom-right corner; click it (or re-run the bookmarklet) to remove every translation and restore the page
+- **Clean teardown** — disconnects the observer, drops the scroll listener, removes all injected nodes and data attributes
+
+## Installation
+
+### Easy Mode
+1. Go to the [BSky Translator Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html?bookmarklet=bsky_translator.js)
+2. Drag the link to your bookmarks bar
+
+### Hard Mode
+1. Copy the entire JavaScript code from the bookmarklet file at https://github.com/oaustegard/bookmarklets/blob/main/bsky_translator.js
+2. Go to [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html)
+3. Paste the code
+4. Name the bookmarklet (e.g., "BSky Translate")
+5. Drag the link to your bookmarks bar
+
+## Usage
+
+1. Open any Bluesky feed, profile, or thread at `https://bsky.app/`
+2. Click the bookmarklet
+3. A blue **EN translate: ON (click to stop)** badge appears in the bottom-right corner
+4. Non-English posts get an English block appended beneath them, prefixed with the detected source language
+5. Keep scrolling — newly rendered posts are translated automatically
+6. To stop, either click the badge or click the bookmarklet a second time. All translation blocks and the badge are removed
+
+## How It Works
+
+**Post discovery.** Two selectors run against the document on every scan:
+
+```javascript
+'[data-testid="postText"],[data-testid^="postThreadItem-by-"] [data-word-wrap]'
+```
+
+Feed posts carry `data-testid="postText"`. Posts on the thread detail page do not — there the text lives in a `[data-word-wrap]` node inside a `postThreadItem-by-<handle>` container, so both shapes are matched.
+
+**Visibility filter.** Bluesky virtualizes long lists, keeping off-screen nodes in the DOM unrendered. Each candidate is checked with `e.offsetParent || e.getClientRects().length` so only actually-rendered posts are queued.
+
+**Change detection.** Each processed node gets its post text stamped onto `dataset.trKey`. That single attribute serves as both the "already handled" marker and the staleness check: when Bluesky recycles a node for a different post, the text no longer matches the stored key and the node is re-queued.
+
+**Translation.** Text is sent to the public Google Translate endpoint:
+
+```
+https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=<text>
+```
+
+The response's segments are joined into one string and `j[2]` gives the auto-detected source language.
+
+**Queue drain.** A single async drainer processes the queue serially, pausing 200 ms between network calls. Before rendering, it re-checks `isConnected` and `trKey` — the node may have been recycled while the request was in flight.
+
+**Caching.** Results are keyed by post text in a `Map`. Negative results are cached too: if the detected source is already `en`, or the translation comes back empty or identical to the input, a `{skip:1}` sentinel is stored so the same text is never re-fetched.
+
+**Scheduling.** A `MutationObserver` on `document.body` and a capture-phase `scroll` listener both funnel into a 250 ms debounced rescan.
+
+**Teardown.** `window.__bskyTr.stop()` sets the loop flag to 0, disconnects the observer, removes the scroll listener and badge, deletes every `[data-bsky-tr]` block, clears every `trKey` attribute, and removes the global. Running the bookmarklet while it is already active calls `stop()` and returns, making the bookmarklet a toggle.
+
+## Technical Notes
+
+- **Unofficial endpoint.** `translate.googleapis.com/translate_a/single` is the undocumented endpoint the Google Translate web UI uses. It needs no API key and is CORS-permissive, but it is not a supported API — it can rate-limit or change response shape without notice. Failed requests are swallowed per-post; the rest of the queue continues.
+- **Post text is sent to Google.** Every non-English post you scroll past is transmitted to Google's translation endpoint. Nothing else leaves the page and nothing is stored beyond the in-memory cache, which dies with the tab.
+- **Language detection is per-post.** Short posts, emoji-heavy posts, and proper nouns are often misdetected as English and therefore skipped.
+- **Cache is per-session.** Reloading the page clears it.
+- **DOM-selector dependent.** Bluesky ships frequent UI changes; if translations stop appearing, the `data-testid` selectors are the first thing to check.
+- Requires a modern browser (`async`/`await`, `MutationObserver`, `fetch`).
+
+## Source Code
+
+https://github.com/oaustegard/bookmarklets/blob/main/bsky_translator.js
+
+## License
+
+MIT License - See [LICENSE](https://github.com/oaustegard/bookmarklets/blob/main/LICENSE)
+
+## Author
+
+Concept and edits by [Oskar Austegard](https://austegard.com). Code and README by Claude.


### PR DESCRIPTION
Updates `bsky_translator.js` to the revised implementation and adds the missing documentation.

## Changes

**`bsky_translator.js`**
- **Thread detail posts now translate.** The old selector only matched `[data-testid="postText"]`, which the thread detail view doesn't use. Added `[data-testid^="postThreadItem-by-"] [data-word-wrap]` so replies on a thread page are picked up too.
- **Visibility filter.** Bluesky virtualizes long lists, leaving unrendered nodes in the DOM. Candidates are now filtered on `offsetParent || getClientRects().length`, so off-screen slots aren't queued for translation.
- **Restructured queue drainer.** The `pump`/`scan` split is folded into a single drainer invoked at the end of each scan, with the `isConnected` / `trKey` staleness re-check moved inside the loop body rather than a `continue` guard.
- **Negative results cached.** A `{skip:1}` sentinel is stored for text detected as already-English (or where the translation comes back empty/identical), so the same post text is never re-fetched on subsequent scans.
- Debounce raised from 200 ms to 250 ms; label separator is now `→` (`→`) instead of `>`.
- Kept pretty-printed with the repo's `@title` / `@description` / `@domains` metadata header and `%23` for CSS hex colors (the file is consumed as a `javascript:` URL, which percent-decodes before evaluating).

**`bsky_translator_README.md`** (new) — follows the repo README template: Purpose, Features, Installation (Easy/Hard Mode), Usage, How It Works, Technical Notes, Source Code, License, Author. The Technical Notes call out that the Google Translate endpoint is undocumented and that post text is transmitted to it.

**`CONTENT_SUMMARY.md`** — added the BSky Translator entry, which was missing.

## Testing

Ran both the supplied source and the pretty-printed repo file through a jsdom harness with a fake Bluesky DOM (feed posts + `postThreadItem-by-*` thread posts) and a stubbed translate endpoint. Behavior is identical between the two, and:

- Duplicate post text produced one fetch, two rendered translations (cache hit).
- English posts got no translation block, and no repeat fetch on rescan.
- A post appended after load (simulated infinite scroll) was picked up by the observer and translated.
- A no-op mutation triggered 0 extra fetches.
- `%23` decoded to a valid color (`rgb(10, 122, 255)`).
- Toggle: 1st invoke on, 2nd invoke off (0 leftover translation nodes, badge removed, `trKey` attributes cleared, global deleted), 3rd invoke back on.

Not tested against live bsky.app — the selector changes should be confirmed on a real feed and thread page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKLBkb9DAMytNcsPRPXGbu


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKLBkb9DAMytNcsPRPXGbu)_