### PR TITLE
Add claude_save_response bookmarklet

### DIFF
--- a/claude_save_response.js
+++ b/claude_save_response.js
@@ -1,0 +1,88 @@
+javascript:(function () {
+  /* Save Claude's last response as a .md file, named after the chat title */
+  console.log('Bookmarklet: Starting');
+  try {
+    /* --- Locate the copy button for the last response --- */
+    var buttons = document.querySelectorAll('button[aria-label="Copy"]');
+    if (!buttons.length) {
+      alert('✗ Element not found: no Copy button on this page.');
+      return;
+    }
+    var copyButton = buttons[buttons.length - 1];
+
+    /* --- Derive the filename from the chat title --- */
+    var titleEl = document.querySelector('[data-testid="chat-title-split"]');
+    var rawTitle = titleEl ? (titleEl.innerText || '') : '';
+    var fileName = rawTitle
+      .replace(/[\\/:*?"<>|]/g, '-')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 120)
+      .replace(/[\s.]+$/, '');
+    if (!fileName) { fileName = 'claude-response'; }
+    fileName = fileName + '.md';
+    console.log('Bookmarklet: Target filename', fileName);
+
+    /* --- Intercept the copy instead of reading the clipboard back --- */
+    var captured = null;
+    var originalWriteText = navigator.clipboard && navigator.clipboard.writeText
+      ? navigator.clipboard.writeText.bind(navigator.clipboard)
+      : null;
+
+    if (originalWriteText) {
+      navigator.clipboard.writeText = function (text) {
+        captured = text;
+        return Promise.resolve();
+      };
+    }
+
+    var onCopy = function (e) {
+      if (e.clipboardData) {
+        var data = e.clipboardData.getData('text/plain');
+        if (data) { captured = data; }
+      }
+    };
+    document.addEventListener('copy', onCopy, true);
+
+    var restore = function () {
+      if (originalWriteText) { navigator.clipboard.writeText = originalWriteText; }
+      document.removeEventListener('copy', onCopy, true);
+    };
+
+    /* --- Trigger the app's own copy handler --- */
+    copyButton.click();
+
+    /* --- Give the handler a moment, then write the file --- */
+    setTimeout(function () {
+      try {
+        restore();
+        if (!captured) {
+          alert('✗ Could not capture the response markdown.');
+          console.log('Bookmarklet: Complete (no content)');
+          return;
+        }
+        console.log('Bookmarklet: Captured', captured.length, 'characters');
+
+        var blob = new Blob([captured], { type: 'text/markdown;charset=utf-8' });
+        var url = URL.createObjectURL(blob);
+        var link = document.createElement('a');
+        link.href = url;
+        link.download = fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
+
+        alert('✓ Saved ' + fileName + ' (' + captured.length + ' characters)');
+        console.log('Bookmarklet: Complete');
+      } catch (inner) {
+        restore();
+        console.error('Bookmarklet error:', inner);
+        alert('Operation failed: ' + inner.message);
+      }
+    }, 600);
+  } catch (e) {
+    console.error('Bookmarklet error:', e);
+    alert('Operation failed: ' + e.message);
+  }
+})();

--- a/claude_save_response_README.md
+++ b/claude_save_response_README.md
@@ -1,0 +1,56 @@
+# Claude Save Response
+
+Saves Claude's most recent response as a `.md` file, named after the chat title.
+
+## Purpose
+
+Claude.ai has no built-in "export this response" action — the only path is the Copy button, followed by pasting into a text editor and saving by hand. This bookmarklet collapses that into one click: it triggers the page's own Copy button, intercepts the markdown it produces, and downloads it as a file named after the current chat.
+
+## Features
+
+- **One-click export**: Click the bookmarklet on any Claude.ai chat to download the last response.
+- **Chat-title filename**: Reads the chat title from the page and sanitizes it into a safe filename (illegal characters stripped, truncated to 120 characters); falls back to `claude-response.md` if no title is found.
+- **No clipboard round-trip**: Rather than reading back from the OS clipboard (unreliable without an explicit paste gesture), it intercepts `navigator.clipboard.writeText` and the `copy` event directly, so the captured content is exactly what the Copy button produced.
+- **Console logging**: Logs each step (target filename, captured length, completion) to the console for troubleshooting.
+- **User feedback**: Alerts on success (with filename and character count) or on failure (missing Copy button, no content captured).
+
+## Installation
+
+### Easy Install
+1. Visit the [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html?bookmarklet=claude_save_response.js)
+2. Drag the created bookmarklet to your bookmarks bar.
+
+### Manual Install
+1. Create a new bookmark in your browser.
+2. Set the name to "Save Claude Response".
+3. Set the URL to the JavaScript code found in [`claude_save_response.js`](https://github.com/oaustegard/bookmarklets/blob/main/claude_save_response.js).
+4. Save the bookmark.
+
+## Usage
+
+1. Open a conversation on claude.ai and let Claude finish a response.
+2. Click the "Save Claude Response" bookmarklet.
+3. The browser downloads a `.md` file named after the chat title (e.g. `My Chat Title.md`), containing the last response's markdown.
+4. An alert confirms the filename and character count once the download starts.
+
+## How It Works
+
+1. **Finds the Copy button**: Queries `button[aria-label="Copy"]` and takes the last match on the page, which corresponds to the most recent assistant response.
+2. **Derives the filename**: Reads `[data-testid="chat-title-split"]`, strips filesystem-illegal characters (`\ / : * ? " < > |`), collapses whitespace, trims trailing spaces/periods, and truncates to 120 characters.
+3. **Intercepts the copy**: Temporarily wraps `navigator.clipboard.writeText` so any call captures its argument instead of touching the OS clipboard, and adds a `copy` event listener as a fallback for `document.execCommand`-based copying. Both are restored afterward.
+4. **Triggers the app's copy action**: Calls `.click()` on the Copy button so Claude's own UI code produces the markdown, rather than re-deriving it from the DOM.
+5. **Writes the file**: After a short delay (600ms) for the copy handler to run, wraps the captured text in a `Blob`, creates an object URL, and triggers a download via a temporary anchor element with a `download` attribute.
+
+## Technical Notes
+
+- Depends on Claude.ai's current DOM structure — specifically the `aria-label="Copy"` button and the `data-testid="chat-title-split"` title element. If Claude.ai changes these, the bookmarklet will need updating.
+- The 600ms delay between clicking Copy and reading the captured value is a fixed wait, not an event-driven signal; on a slow page it's possible (though unobserved) for the capture to fire before the app's copy handler completes.
+- Runs entirely client-side; no data leaves the browser.
+
+## License
+
+MIT License - See [LICENSE](https://github.com/oaustegard/bookmarklets/blob/main/LICENSE)
+
+## Author
+
+Created by [Oskar Austegard](https://austegard.com)


### PR DESCRIPTION
Adds a bookmarklet that saves Claude's last response as a `.md` file, named after the chat title.

- Triggers the page's own Copy button (aria-label="Copy") and intercepts the markdown via `navigator.clipboard.writeText` + a `copy` event listener, rather than re-deriving content from the DOM or reading the OS clipboard back.
- Filename derived from `[data-testid="chat-title-split"]`, sanitized and truncated to 120 chars.
- README follows the standard structure from `.claude/commands/document_command.md`.

Note: pushing to `main` will trigger `auto_readme.yml`, which regenerates `*_README.md` via GitHub Models AI for any changed root `.js` file — so this hand-written README may get overwritten by an AI-generated one on merge. Flagging in case that's not wanted for this file; happy to have it excluded if so.