### PR TITLE
Fix claude_save_response: title-glyph filename bug, drop success alert

### DIFF
--- a/claude_save_response.js
+++ b/claude_save_response.js
@@ -17,6 +17,9 @@ javascript:
     var titleEl = document.querySelector('[data-testid="chat-title-split"]');
     var rawTitle = titleEl ? (titleEl.innerText || '') : '';
     var fileName = rawTitle
+      .normalize('NFKC')
+      .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u2028-\u202F\u205F-\u206F\uFE00-\uFE0F\uFEFF\uE000-\uF8FF]/g, '')
+      .replace(/[\u{1F000}-\u{1FFFF}\u2190-\u2BFF]/gu, '')
       .replace(/[\\/:*?"<>|]/g, '-')
       .replace(/\s+/g, ' ')
       .trim()
@@ -76,8 +79,7 @@ javascript:
         document.body.removeChild(link);
         setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
 
-        alert('✓ Saved ' + fileName + ' (' + captured.length + ' characters)');
-        console.log('Bookmarklet: Complete');
+        console.log('Bookmarklet: Complete —', fileName, '(' + captured.length + ' characters)');
       } catch (inner) {
         restore();
         console.error('Bookmarklet error:', inner);

--- a/claude_save_response_README.md
+++ b/claude_save_response_README.md
@@ -8,11 +8,11 @@ Claude.ai has no built-in "export this response" action — the only path is the
 
 ## Features
 
-- **One-click export**: Click the bookmarklet on any Claude.ai chat to download the last response.
-- **Chat-title filename**: Reads the chat title from the page and sanitizes it into a safe filename (illegal characters stripped, truncated to 120 characters); falls back to `claude-response.md` if no title is found.
+- **One-click export**: Click the bookmarklet on any Claude.ai chat to download the last response — no success popup, it just downloads.
+- **Chat-title filename**: Reads the chat title from the page and sanitizes it into a safe filename — strips control characters, zero-width characters, and icon/emoji glyphs (UI badges appended to the title can otherwise leak into the filename), replaces filesystem-illegal characters, collapses whitespace, and truncates to 120 characters; falls back to `claude-response.md` if no title is found.
 - **No clipboard round-trip**: Rather than reading back from the OS clipboard (unreliable without an explicit paste gesture), it intercepts `navigator.clipboard.writeText` and the `copy` event directly, so the captured content is exactly what the Copy button produced.
 - **Console logging**: Logs each step (target filename, captured length, completion) to the console for troubleshooting.
-- **User feedback**: Alerts on success (with filename and character count) or on failure (missing Copy button, no content captured).
+- **Failure feedback only**: Alerts only when something goes wrong (missing Copy button, no content captured, an error) — silent on success.
 
 ## Installation
 
@@ -36,10 +36,10 @@ Claude.ai has no built-in "export this response" action — the only path is the
 ## How It Works
 
 1. **Finds the Copy button**: Queries `button[aria-label="Copy"]` and takes the last match on the page, which corresponds to the most recent assistant response.
-2. **Derives the filename**: Reads `[data-testid="chat-title-split"]`, strips filesystem-illegal characters (`\ / : * ? " < > |`), collapses whitespace, trims trailing spaces/periods, and truncates to 120 characters.
+2. **Derives the filename**: Reads `[data-testid="chat-title-split"]`, then runs the raw title through a sanitization pipeline: Unicode-normalizes it (`NFKC`), strips control/zero-width/variation-selector/private-use-area characters and pictographic/arrow glyphs (icon-font badges the UI can append to the title text otherwise survive into the filename as stray underscores), replaces filesystem-illegal characters (`\ / : * ? " < > |`) with `-`, collapses whitespace, trims trailing spaces/periods, and truncates to 120 characters.
 3. **Intercepts the copy**: Temporarily wraps `navigator.clipboard.writeText` so any call captures its argument instead of touching the OS clipboard, and adds a `copy` event listener as a fallback for `document.execCommand`-based copying. Both are restored afterward.
 4. **Triggers the app's copy action**: Calls `.click()` on the Copy button so Claude's own UI code produces the markdown, rather than re-deriving it from the DOM.
-5. **Writes the file**: After a short delay (600ms) for the copy handler to run, wraps the captured text in a `Blob`, creates an object URL, and triggers a download via a temporary anchor element with a `download` attribute.
+5. **Writes the file**: After a short delay (600ms) for the copy handler to run, wraps the captured text in a `Blob`, creates an object URL, and triggers a download via a temporary anchor element with a `download` attribute. Success is logged to the console only — no alert.
 
 ## Technical Notes
 


### PR DESCRIPTION
Follow-up to #53.

- Filename sanitizer now strips control/zero-width/variation-selector/private-use-area characters and pictographic/arrow glyphs before building the filename. Root cause of the `..._ownership__.md` double-underscore: a UI badge glyph appended to the chat title survived our old sanitizer (it only handled the classic Windows-illegal characters), then got mangled into underscores downstream.
- Removed the success `alert()` — console-only on success now, alerts remain for actual failures (no Copy button, no content captured, thrown errors).
- README updated to match (Features + How It Works).

Branched fresh from current `main`, which already had the `@title`/`@description`/`@domains` frontmatter (pushed directly, commit eaa05307).