### PR TITLE
Fix claude_save_response: read clipboard back instead of intercepting writeText

### DIFF
--- a/claude_save_response.js
+++ b/claude_save_response.js
@@ -29,63 +29,64 @@ javascript:
     fileName = fileName + '.md';
     console.log('Bookmarklet: Target filename', fileName);
 
-    /* --- Intercept the copy instead of reading the clipboard back --- */
-    var captured = null;
-    var originalWriteText = navigator.clipboard && navigator.clipboard.writeText
-      ? navigator.clipboard.writeText.bind(navigator.clipboard)
-      : null;
-
-    if (originalWriteText) {
-      navigator.clipboard.writeText = function (text) {
-        captured = text;
-        return Promise.resolve();
-      };
+    if (!navigator.clipboard || !navigator.clipboard.readText) {
+      alert('✗ Clipboard read is not available in this browser.');
+      return;
     }
 
-    var onCopy = function (e) {
-      if (e.clipboardData) {
-        var data = e.clipboardData.getData('text/plain');
-        if (data) { captured = data; }
-      }
+    /* --- Trigger the app's own copy handler, then read the OS clipboard back.
+       The site's copy write is async and not reliably interceptable (it may
+       hold a bound reference to navigator.clipboard.writeText from before
+       this bookmarklet ran), so read the real clipboard instead — with a
+       short retry loop since the write may not have landed yet. --- */
+    var readClipboardWithRetry = function (retriesLeft, delay) {
+      return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+          navigator.clipboard.readText().then(function (text) {
+            if (text || retriesLeft <= 0) {
+              resolve(text);
+            } else {
+              readClipboardWithRetry(retriesLeft - 1, delay).then(resolve, reject);
+            }
+          }).catch(function (err) {
+            if (retriesLeft <= 0) {
+              reject(err);
+            } else {
+              readClipboardWithRetry(retriesLeft - 1, delay).then(resolve, reject);
+            }
+          });
+        }, delay);
+      });
     };
-    document.addEventListener('copy', onCopy, true);
 
-    var restore = function () {
-      if (originalWriteText) { navigator.clipboard.writeText = originalWriteText; }
-      document.removeEventListener('copy', onCopy, true);
-    };
-
-    /* --- Trigger the app's own copy handler --- */
     copyButton.click();
 
-    /* --- Give the handler a moment, then write the file --- */
-    setTimeout(function () {
-      try {
-        restore();
-        if (!captured) {
-          alert('✗ Could not capture the response markdown.');
-          console.log('Bookmarklet: Complete (no content)');
-          return;
-        }
-        console.log('Bookmarklet: Captured', captured.length, 'characters');
-
-        var blob = new Blob([captured], { type: 'text/markdown;charset=utf-8' });
-        var url = URL.createObjectURL(blob);
-        var link = document.createElement('a');
-        link.href = url;
-        link.download = fileName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
-
-        console.log('Bookmarklet: Complete —', fileName, '(' + captured.length + ' characters)');
-      } catch (inner) {
-        restore();
-        console.error('Bookmarklet error:', inner);
-        alert('Operation failed: ' + inner.message);
+    readClipboardWithRetry(4, 200).then(function (captured) {
+      if (!captured) {
+        alert('✗ Clipboard was empty after copying. Try again, or make sure this tab has focus.');
+        console.log('Bookmarklet: Complete (no content)');
+        return;
       }
-    }, 600);
+      console.log('Bookmarklet: Captured', captured.length, 'characters');
+
+      var blob = new Blob([captured], { type: 'text/markdown;charset=utf-8' });
+      var url = URL.createObjectURL(blob);
+      var link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(function () { URL.revokeObjectURL(url); }, 2000);
+
+      console.log('Bookmarklet: Complete —', fileName, '(' + captured.length + ' characters)');
+    }).catch(function (err) {
+      console.error('Bookmarklet error:', err);
+      var hint = err && err.name === 'NotAllowedError'
+        ? ' — grant clipboard-read permission for this site and try again.'
+        : ': ' + (err && err.message);
+      alert('✗ Could not read the clipboard' + hint);
+    });
   } catch (e) {
     console.error('Bookmarklet error:', e);
     alert('Operation failed: ' + e.message);

--- a/claude_save_response_README.md
+++ b/claude_save_response_README.md
@@ -4,13 +4,13 @@ Saves Claude's most recent response as a `.md` file, named after the chat title.
 
 ## Purpose
 
-Claude.ai has no built-in "export this response" action — the only path is the Copy button, followed by pasting into a text editor and saving by hand. This bookmarklet collapses that into one click: it triggers the page's own Copy button, intercepts the markdown it produces, and downloads it as a file named after the current chat.
+Claude.ai has no built-in "export this response" action — the only path is the Copy button, followed by pasting into a text editor and saving by hand. This bookmarklet collapses that into one click: it triggers the page's own Copy button, reads the resulting markdown back from the clipboard, and downloads it as a file named after the current chat.
 
 ## Features
 
 - **One-click export**: Click the bookmarklet on any Claude.ai chat to download the last response — no success popup, it just downloads.
 - **Chat-title filename**: Reads the chat title from the page and sanitizes it into a safe filename — strips control characters, zero-width characters, and icon/emoji glyphs (UI badges appended to the title can otherwise leak into the filename), replaces filesystem-illegal characters, collapses whitespace, and truncates to 120 characters; falls back to `claude-response.md` if no title is found.
-- **No clipboard round-trip**: Rather than reading back from the OS clipboard (unreliable without an explicit paste gesture), it intercepts `navigator.clipboard.writeText` and the `copy` event directly, so the captured content is exactly what the Copy button produced.
+- **Reads the real clipboard**: Triggers the page's own Copy button, then reads the result back with `navigator.clipboard.readText()`, retrying briefly since the site's clipboard write is asynchronous. (An earlier version tried to intercept `navigator.clipboard.writeText` directly, but Claude.ai's copy handler holds its own bound reference to that method from before the bookmarklet runs, so the override was never actually called — the real clipboard write always went through untouched.)
 - **Console logging**: Logs each step (target filename, captured length, completion) to the console for troubleshooting.
 - **Failure feedback only**: Alerts only when something goes wrong (missing Copy button, no content captured, an error) — silent on success.
 
@@ -30,21 +30,21 @@ Claude.ai has no built-in "export this response" action — the only path is the
 
 1. Open a conversation on claude.ai and let Claude finish a response.
 2. Click the "Save Claude Response" bookmarklet.
-3. The browser downloads a `.md` file named after the chat title (e.g. `My Chat Title.md`), containing the last response's markdown.
-4. An alert confirms the filename and character count once the download starts.
+3. The browser downloads a `.md` file named after the chat title (e.g. `My Chat Title.md`), containing the last response's markdown. On the first use, the browser may prompt to allow clipboard access for claude.ai — allow it.
 
 ## How It Works
 
 1. **Finds the Copy button**: Queries `button[aria-label="Copy"]` and takes the last match on the page, which corresponds to the most recent assistant response.
 2. **Derives the filename**: Reads `[data-testid="chat-title-split"]`, then runs the raw title through a sanitization pipeline: Unicode-normalizes it (`NFKC`), strips control/zero-width/variation-selector/private-use-area characters and pictographic/arrow glyphs (icon-font badges the UI can append to the title text otherwise survive into the filename as stray underscores), replaces filesystem-illegal characters (`\ / : * ? " < > |`) with `-`, collapses whitespace, trims trailing spaces/periods, and truncates to 120 characters.
-3. **Intercepts the copy**: Temporarily wraps `navigator.clipboard.writeText` so any call captures its argument instead of touching the OS clipboard, and adds a `copy` event listener as a fallback for `document.execCommand`-based copying. Both are restored afterward.
-4. **Triggers the app's copy action**: Calls `.click()` on the Copy button so Claude's own UI code produces the markdown, rather than re-deriving it from the DOM.
-5. **Writes the file**: After a short delay (600ms) for the copy handler to run, wraps the captured text in a `Blob`, creates an object URL, and triggers a download via a temporary anchor element with a `download` attribute. Success is logged to the console only — no alert.
+3. **Triggers the app's copy action**: Calls `.click()` on the Copy button so Claude's own UI code produces the markdown, rather than re-deriving it from the DOM.
+4. **Reads the clipboard with retry**: Calls `navigator.clipboard.readText()` after a short delay; if it comes back empty, retries up to 4 times at 200ms intervals (the site's copy write is async and may not have landed yet). Bails out with a clipboard-permission hint if the read is rejected.
+5. **Writes the file**: Once non-empty text comes back, wraps it in a `Blob`, creates an object URL, and triggers a download via a temporary anchor element with a `download` attribute. Success is logged to the console only — no alert.
 
 ## Technical Notes
 
 - Depends on Claude.ai's current DOM structure — specifically the `aria-label="Copy"` button and the `data-testid="chat-title-split"` title element. If Claude.ai changes these, the bookmarklet will need updating.
-- The 600ms delay between clicking Copy and reading the captured value is a fixed wait, not an event-driven signal; on a slow page it's possible (though unobserved) for the capture to fire before the app's copy handler completes.
+- Uses `navigator.clipboard.readText()`, which requires a secure context and clipboard-read permission for the site. Chrome/Edge typically prompt once and remember the grant; Firefox and Safari restrict programmatic clipboard reads more aggressively and may not work reliably.
+- Overwrites whatever was previously on the clipboard, since it reads back what the Copy button just wrote there.
 - Runs entirely client-side; no data leaves the browser.
 
 ## License


### PR DESCRIPTION
Follow-up to #53/#54.

Root cause of "copy fires, but bookmarklet says it could not capture the response" (the content genuinely is on the OS clipboard): the interception approach — overriding `navigator.clipboard.writeText` and listening for a `copy` DOM event — never actually saw the write. Claude.ai's copy handler most likely holds its own bound reference to `navigator.clipboard.writeText` from before the bookmarklet runs (or writes via `navigator.clipboard.write()` with a `ClipboardItem`, which does not dispatch a `copy` event), so the real write goes straight to the OS clipboard, bypassing both interception points entirely.

Fix: stop trying to intercept, and just read the clipboard back with `navigator.clipboard.readText()` after clicking Copy — with a short retry loop (up to 4 retries, 200ms apart) since the site's write is async and may not have landed on the first read. Also added an upfront check for clipboard-read API availability, and a clipboard-permission-specific hint if the read is rejected.

README updated to match (Purpose, Features, Usage, How It Works, Technical Notes — including the new clipboard-read-permission and browser-support caveats).