### PR TITLE
Claude Code (web) transcript exporter bookmarklet

### DIFF
--- a/claude_code_transcript.js
+++ b/claude_code_transcript.js
@@ -1,0 +1,287 @@
+javascript:
+/* @title: Claude Code Transcript Exporter */
+/* @description: Exports a full Claude Code (web) session transcript as Markdown or JSON, pulling every entry out of the virtualized list's React props */
+/* @domains: claude.ai */
+(function () {
+  /* Claude Code (web) — Full Transcript Exporter
+     Pulls the complete entry list out of the virtualized transcript's React
+     props, so nothing is lost to windowing. Copy as Markdown, download as
+     Markdown, or download raw JSON. */
+
+  try {
+    console.log('CC-Transcript: starting');
+
+    /* ---------- locate the transcript data ---------- */
+
+    function fiberOf(el) {
+      var k = Object.keys(el).filter(function(x) { return x.indexOf('__reactFiber$') === 0; })[0];
+      return k ? el[k] : null;
+    }
+
+    function entriesFrom(el) {
+      var node = fiberOf(el), hops = 0;
+      while (node && hops < 80) {
+        var p = node.memoizedProps;
+        if (p) {
+          if (Array.isArray(p.entries) && p.entries.length) return p.entries;
+          if (Array.isArray(p.baseEntries) && p.baseEntries.length) return p.baseEntries;
+        }
+        node = node.return;
+        hops++;
+      }
+      return null;
+    }
+
+    function collectEntries() {
+      var hosts = document.querySelectorAll('[data-testid="epitaxy-virtual-transcript"]');
+      var seen = [], all = [];
+      for (var i = 0; i < hosts.length; i++) {
+        var e = entriesFrom(hosts[i]);
+        if (e && seen.indexOf(e) === -1) { seen.push(e); all = all.concat(e); }
+      }
+      return all;
+    }
+
+    var entries = collectEntries();
+    if (!entries.length) {
+      alert('✗ No transcript data found.\n\nOpen a Claude Code session page (claude.ai/code/session_...) and let it finish loading, then try again.');
+      return;
+    }
+    console.log('CC-Transcript: entries =', entries.length);
+
+    /* ---------- helpers ---------- */
+
+    function safeJson(value, indent) {
+      var seen = new WeakSet();
+      return JSON.stringify(value, function(k, v) {
+        if (typeof v === 'object' && v !== null) {
+          if (seen.has(v)) return '[Circular]';
+          seen.add(v);
+        }
+        if (typeof v === 'function') return '[Function]';
+        return v;
+      }, indent);
+    }
+
+    function fence(body, lang) {
+      var s = (body === null || body === undefined) ? '' : String(body);
+      var runs = s.match(/`+/g) || [];
+      var longest = 0;
+      runs.forEach(function(r) { if (r.length > longest) longest = r.length; });
+      var bar = new Array(Math.max(3, longest + 1) + 1).join('`');
+      return bar + (lang || '') + '\n' + s + '\n' + bar;
+    }
+
+    function stamp(ts) {
+      if (!ts) return '';
+      try { return new Date(ts).toISOString().replace('T', ' ').replace(/\.\d+Z$/, 'Z'); }
+      catch (e) { return String(ts); }
+    }
+
+    function textOf(v) { return (typeof v === 'string') ? v : safeJson(v, 2); }
+
+    /* ---------- renderers ---------- */
+
+    function renderTool(t) {
+      var out = [];
+      var state = t.isError ? 'ERROR' : (t.status || 'done');
+      out.push('#### 🔧 ' + (t.name || 'tool') + '  `' + state + '`');
+      if (t.policyDenied) out.push('> policy denied');
+
+      if (t.input !== undefined && t.input !== null) {
+        out.push('**Input**\n\n' + fence(safeJson(t.input, 2), 'json'));
+      }
+
+      var res = t.output;
+      if (res === undefined || res === null || res === '') res = t.toolUseResult;
+      if (res === undefined || res === null || res === '') res = t.rawResultContent;
+      if (res !== undefined && res !== null && res !== '') {
+        out.push('**Output**\n\n' + fence(textOf(res)));
+      } else {
+        out.push('**Output**\n\n_(empty)_');
+      }
+      return out.join('\n\n');
+    }
+
+    function renderTaskEvent(ev) {
+      var bits = [];
+      if (ev.taskType) bits.push(ev.taskType);
+      if (ev.status) bits.push('status=' + ev.status);
+      if (ev.durationMs !== undefined && ev.durationMs !== null) bits.push(Math.round(ev.durationMs / 1000) + 's');
+      var line = '- 🧵 **task** ' + (ev.description || ev.taskId || '') + (bits.length ? '  _(' + bits.join(', ') + ')_' : '');
+      if (ev.summary) line += '\n\n' + fence(textOf(ev.summary));
+      return line;
+    }
+
+    function renderItem(item) {
+      var kind = item.kind || item.type || 'unknown';
+
+      if (kind === 'text') return textOf(item.text);
+
+      if (kind === 'thinking') return '> **thinking**\n\n' + fence(textOf(item.thinking || item.text));
+
+      if (kind === 'tools') {
+        var parts = [];
+        (item.tools || []).forEach(function(t) { parts.push(renderTool(t)); });
+        (item.taskEvents || []).forEach(function(ev) { parts.push(renderTaskEvent(ev)); });
+        return parts.join('\n\n');
+      }
+
+      if (kind === 'task_event') return renderTaskEvent(item);
+
+      if (kind === 'error') return '> ⚠️ **error** ' + (item.code ? '`' + item.code + '` ' : '') + (textOf(item.text) || '');
+
+      if (kind === 'turn_error') {
+        return '> ⚠️ **turn error** ' + (item.subtype || '') + '\n\n' + fence(safeJson(item.errors, 2), 'json');
+      }
+
+      /* unknown kind — dump it verbatim so nothing is silently dropped */
+      return '_(' + kind + ')_\n\n' + fence(safeJson(item, 2), 'json');
+    }
+
+    function renderEntry(entry, index) {
+      var who = String(entry.author || 'unknown');
+      var head = who.charAt(0).toUpperCase() + who.slice(1);
+      if (entry.model) head += ' (' + entry.model + ')';
+      var when = stamp(entry.timestamp);
+
+      var lines = ['## ' + (index + 1) + '. ' + head + (when ? ' — ' + when : '')];
+      if (entry.sourceUuid) lines.push('<!-- ' + entry.sourceUuid + ' -->');
+      (entry.items || []).forEach(function(it) {
+        var body = renderItem(it);
+        if (body) lines.push(body);
+      });
+      return lines.join('\n\n');
+    }
+
+    /* ---------- assemble ---------- */
+
+    var sessionMatch = location.pathname.match(/session_[A-Za-z0-9_-]+/);
+    var sessionId = sessionMatch ? sessionMatch[0] : 'transcript';
+    var exportedAt = new Date().toISOString();
+
+    function buildMarkdown() {
+      var header = [
+        '# ' + (document.title || 'Claude Code transcript'),
+        '',
+        '- **Session:** `' + sessionId + '`',
+        '- **URL:** ' + location.origin + location.pathname,
+        '- **Exported:** ' + exportedAt,
+        '- **Entries:** ' + entries.length,
+        '',
+        '---'
+      ].join('\n');
+      var body = entries.map(renderEntry).join('\n\n---\n\n');
+      return header + '\n\n' + body + '\n';
+    }
+
+    function buildJson() {
+      return safeJson({
+        session: sessionId,
+        url: location.origin + location.pathname,
+        title: document.title,
+        exportedAt: exportedAt,
+        entryCount: entries.length,
+        entries: entries
+      }, 2);
+    }
+
+    /* ---------- delivery ---------- */
+
+    function download(text, ext, mime) {
+      var name = 'claude-code-' + sessionId + '-' + exportedAt.slice(0, 10) + '.' + ext;
+      var blob = new Blob([text], { type: mime + ';charset=utf-8' });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = name;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(function() { URL.revokeObjectURL(url); }, 4000);
+      return name;
+    }
+
+    function copy(text, done) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function() { done(true); }, function(err) {
+          console.error('CC-Transcript: clipboard failed', err);
+          done(fallbackCopy(text));
+        });
+      } else {
+        done(fallbackCopy(text));
+      }
+    }
+
+    function fallbackCopy(text) {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = false;
+      try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+      document.body.removeChild(ta);
+      return ok;
+    }
+
+    /* ---------- panel ---------- */
+
+    var old = document.getElementById('cc-transcript-panel');
+    if (old) old.remove();
+
+    var md = buildMarkdown();
+
+    var panel = document.createElement('div');
+    panel.id = 'cc-transcript-panel';
+    panel.style.cssText = 'position:fixed;top:16px;right:16px;z-index:2147483647;background:#1f1e1d;color:#f5f4f2;font:13px/1.5 ui-sans-serif,system-ui,sans-serif;border:1px solid #454340;border-radius:10px;padding:12px 14px;box-shadow:0 8px 30px rgba(0,0,0,.45);min-width:250px';
+
+    var title = document.createElement('div');
+    title.textContent = 'Transcript export';
+    title.style.cssText = 'font-weight:600;margin-bottom:2px';
+
+    var meta = document.createElement('div');
+    meta.textContent = entries.length + ' entries · ' + Math.round(md.length / 1024) + ' KB markdown';
+    meta.style.cssText = 'opacity:.65;margin-bottom:10px;font-size:12px';
+
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:6px;flex-wrap:wrap';
+
+    var status = document.createElement('div');
+    status.style.cssText = 'margin-top:9px;font-size:12px;min-height:16px;color:#c8e6a0';
+
+    function button(label, handler) {
+      var b = document.createElement('button');
+      b.textContent = label;
+      b.style.cssText = 'cursor:pointer;background:#c96442;color:#fff;border:0;border-radius:6px;padding:6px 10px;font:inherit;font-size:12px';
+      b.onclick = handler;
+      row.appendChild(b);
+      return b;
+    }
+
+    button('Copy MD', function() {
+      status.textContent = 'copying…';
+      copy(md, function(ok) { status.textContent = ok ? '✓ copied to clipboard' : '✗ copy blocked — use Download'; });
+    });
+    button('Download MD', function() { status.textContent = '✓ ' + download(md, 'md', 'text/markdown'); });
+    button('Download JSON', function() { status.textContent = '✓ ' + download(buildJson(), 'json', 'application/json'); });
+
+    var close = document.createElement('button');
+    close.textContent = '×';
+    close.style.cssText = 'cursor:pointer;background:transparent;color:#f5f4f2;border:0;font:inherit;font-size:18px;line-height:1;position:absolute;top:8px;right:10px;opacity:.6';
+    close.onclick = function() { panel.remove(); };
+
+    panel.appendChild(close);
+    panel.appendChild(title);
+    panel.appendChild(meta);
+    panel.appendChild(row);
+    panel.appendChild(status);
+    document.body.appendChild(panel);
+
+    console.log('CC-Transcript: ready,', md.length, 'chars of markdown');
+  } catch (error) {
+    console.error('CC-Transcript error:', error);
+    alert('✗ Transcript export failed: ' + error.message);
+  }
+})();

--- a/claude_code_transcript_README.md
+++ b/claude_code_transcript_README.md
@@ -1,0 +1,67 @@
+# Claude Code Transcript Exporter
+
+Exports a complete Claude Code (web) session transcript as Markdown or JSON.
+
+## Purpose
+
+Claude Code session pages render the transcript in a virtualized list — only the entries near the viewport exist in the DOM, so scraping the page gives you a slice of the conversation rather than the whole thing, and "select all, copy" loses everything that scrolled out. This bookmarklet reads the entry array straight off the React fiber backing the transcript component, which holds every entry regardless of what is on screen, and hands it back as Markdown or raw JSON.
+
+Useful for archiving a session, feeding a transcript to another model, diffing two runs of the same task, or reviewing tool inputs and outputs that the UI collapses.
+
+## Features
+
+- **Nothing lost to windowing**: Reads `entries` (or `baseEntries`) from the component's `memoizedProps`, walking up to 80 fiber parents from each `[data-testid="epitaxy-virtual-transcript"]` host, so the export covers the full session rather than the rendered window.
+- **Three outputs**: Copy Markdown to the clipboard, download Markdown, or download the raw JSON entry array.
+- **Tool calls rendered in full**: Each tool gets a heading with its status (`done`, `ERROR`, or the reported `status`), its input as fenced JSON, and its output — falling back through `output`, `toolUseResult`, and `rawResultContent` — with policy-denied calls marked.
+- **Thinking blocks, task events, and errors preserved**: Extended thinking is fenced under a blockquote label; sub-agent task events render as a line with type, status, and duration in seconds; turn errors dump their error array as JSON.
+- **Unknown entry kinds dumped, not dropped**: Any item type the renderer does not recognize is written out verbatim as JSON under its kind name, so a UI change degrades the export instead of silently truncating it.
+- **Safe serialization**: A `WeakSet`-based replacer marks circular references as `[Circular]` and functions as `[Function]`, so React's cyclic prop graph does not throw on stringify.
+- **Adaptive code fences**: Fence length is computed from the longest backtick run in the content, so output containing Markdown code blocks does not break the surrounding fence.
+- **Clipboard fallback**: Uses `navigator.clipboard.writeText()` and falls back to a hidden textarea with `document.execCommand('copy')` when the async clipboard API is blocked; the panel says which happened.
+- **Filenames carry the session ID**: Downloads are named `claude-code-<session_id>-<YYYY-MM-DD>.md` / `.json`, with the session ID parsed from the URL path.
+
+## Installation
+
+### Easy Install
+1. Visit the [Bookmarklet Installer](https://austegard.com/web-utilities/bookmarklet-installer.html?bookmarklet=claude_code_transcript.js)
+2. Drag the created bookmarklet to your bookmarks bar.
+
+### Manual Install
+1. Create a new bookmark in your browser.
+2. Set the name to "Claude Code Transcript".
+3. Set the URL to the JavaScript code found in [`claude_code_transcript.js`](https://github.com/oaustegard/bookmarklets/blob/main/claude_code_transcript.js).
+4. Save the bookmark.
+
+## Usage
+
+1. Open a Claude Code session page (`claude.ai/code/session_...`) and let it finish loading.
+2. Click the "Claude Code Transcript" bookmarklet.
+3. A panel appears in the top right showing the entry count and the Markdown size in KB.
+4. Click **Copy MD**, **Download MD**, or **Download JSON**. The status line under the buttons reports the result — the copied confirmation, or the filename written.
+5. Click **×** to dismiss the panel. Re-running the bookmarklet replaces any panel already on the page.
+
+If no transcript data is found, an alert says so; the usual cause is running it before the session has loaded, or on a page that is not a session page.
+
+## How It Works
+
+1. **Finds the transcript hosts**: Queries every `[data-testid="epitaxy-virtual-transcript"]` element on the page.
+2. **Walks the fiber tree**: For each host, reads the `__reactFiber$...` key, then climbs `node.return` up to 80 levels looking for a `memoizedProps` carrying a non-empty `entries` or `baseEntries` array. Arrays already seen are skipped by identity, so multiple hosts sharing one array do not duplicate entries.
+3. **Renders each entry**: Emits a numbered `##` heading with the author, the model when present, and an ISO timestamp; the `sourceUuid` goes in an HTML comment. Items dispatch by `kind` (or `type`) to per-kind renderers for text, thinking, tools, task events, errors, and turn errors, with the unknown-kind path dumping raw JSON.
+4. **Assembles the document**: Prepends a header block with the session ID, page URL, export timestamp, and entry count, then joins entries with `---` separators. The JSON build wraps the same metadata around the untouched entry array.
+5. **Delivers**: Downloads go through a `Blob`, an object URL, and a temporary anchor with a `download` attribute, revoking the URL after four seconds. Copying tries the async clipboard API first and the `execCommand` textarea second.
+
+## Technical Notes
+
+- Depends on Claude Code's internal structure — the `epitaxy-virtual-transcript` test ID, the React fiber property naming, and the `entries` prop shape. All three are implementation details of the app, not a public API, so this will need updating when they change.
+- React fiber keys are only exposed in development-style builds and in production builds that have not stripped them; if `__reactFiber$` is absent the bookmarklet reports no transcript data.
+- The Markdown output includes full tool inputs and outputs, which for file-reading or search-heavy sessions can run to megabytes. The panel shows the size before you commit to copying.
+- Extended thinking blocks are included in the export.
+- Runs entirely client-side; nothing is sent anywhere.
+
+## License
+
+MIT License - See [LICENSE](https://github.com/oaustegard/bookmarklets/blob/main/LICENSE)
+
+## Author
+
+Created by [Oskar Austegard](https://austegard.com)


### PR DESCRIPTION
Adds `claude_code_transcript.js` — exports a full Claude Code (web) session transcript as Markdown or JSON.

The transcript list is virtualized, so DOM scraping only reaches the rendered window. This reads the `entries` array off the React fiber behind `[data-testid="epitaxy-virtual-transcript"]`, which holds the whole session. Panel offers Copy MD / Download MD / Download JSON.

Two changes to the file as Oskar sent it, both convention rather than behavior:
- renamed `claudecodetranscript.js` to `claude_code_transcript.js` for the repo's snake_case naming
- added the `javascript:` line and the `@title` / `@description` / `@domains` header comments the installer reads; the original opened with `javascript:(function() {` on one line and no metadata

Body of the script is unchanged.

`claude_code_transcript_README.md` follows the CLAUDE.md template (Purpose, Features, Installation, Usage, How It Works, Source Code).

One note: `auto_readme.yml` fires on any root-level `.js` push to main, so merging this will regenerate `claude_code_transcript_README.md` via GitHub Models and overwrite the hand-written one. Delete the JS-triggered README job, skip it for this file, or accept the regenerated version.

Not verified in-session: no test harness in this repo. `node --check` passes on the file.

*Filed by Muninn*
